### PR TITLE
Add standalone installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ script in `/usr/local/bin` that reads the .env file and put corresponding entrie
 advance, it will trigger the first run immediately. Otherwise it'll tell you where to put the file so you can run it later.
 
 The corresponding crontabs will run weekly and on every reboot. It does assume the `@reboot` extension is available in your flavor
-of cron, as there is no equivalent specifiable time expression for it. The weekly job is defined as `0 0 * * 0` for compatibility.
+of cron, as there is no equivalent specifiable time expression for it. The weekly job is defined as `0 0 * * 1` for compatibility.
 
 ### Changing the run schedule
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ of cron, as there is no equivalent specifiable time expression for it. The weekl
 
 By default, the script is run once per week,
 which is plenty since the certificate is valid for 3 months.
-You can change the schedule by modifying `systemd/porkcron.timer` (for systemd) or `docker/crontab` (for Docker).
+You can change the schedule by modifying `systemd/porkcron.timer` (for systemd) or `crontabs/porkcron.weekly` (for Docker and cron).
 
 ### Configuring a web server
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ docker compose up
 
 This will create the `porkcron` container and download the certificate bundle into the `ssl` volume.
 
+### Standalone for use with cron
+
+If you're using FreeBSD or any other OS that doesn't come with systemd timers, but that does provide cron you can use the following:
+
+```sh
+cd standalone
+chmod +x install.sh
+./standalone/install.sh
+```
+
+It ensures the install script is executable if git didn't preserve the executable bit, before running it. It will install a wrapper
+script in `/usr/local/bin` that reads the .env file and put corresponding entries in `/etc/cron.d`. If you prepared a .env file in
+advance, it will trigger the first run immediately. Otherwise it'll tell you where to put the file so you can run it later.
+
+The corresponding crontabs will run weekly and on every reboot. It does assume the `@reboot` extension is available in your flavor
+of cron, as there is no equivalent specifiable time expression for it. The weekly job is defined as `0 0 * * 0` for compatibility.
+
 ### Changing the run schedule
 
 By default, the script is run once per week,

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ chmod +x install.sh
 ./standalone/install.sh
 ```
 
+> [!WARNING]
+> If you are using BusyBox cron or another "embedded" cron implementation, it might not read `/etc/cron.d` by default. In this case
+> you will have to adjust the install script, symlink the directory, or add the proper entries to your flavor of cron yourself.
+>
+> You can find an example approach to doing this in [The Dockerfile][10] which uses the Python overlay on the Alpine image.
+
 It ensures the install script is executable if git didn't preserve the executable bit, before running it. It will install a wrapper
 script in `/usr/local/bin` that reads the .env file and put corresponding entries in `/etc/cron.d`. If you prepared a .env file in
 advance, it will trigger the first run immediately. Otherwise it'll tell you where to put the file so you can run it later.
@@ -121,3 +127,4 @@ The rest is up to you, happy hacking!
 [7]: https://kb.porkbun.com/article/190-getting-started-with-the-porkbun-dns-api
 [8]: https://nginx.org
 [9]: https://ssl-config.mozilla.org
+[10]: https://github.com/tmzane/porkcron/blob/main/docker/Dockerfile

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docker compose up
 
 This will create the `porkcron` container and download the certificate bundle into the `ssl` volume.
 
-### Standalone for use with cron
+### Using cron
 
 If you're using FreeBSD or any other OS that doesn't come with systemd timers, but that does provide cron you can use the following:
 

--- a/crontabs/porkcron.reboot
+++ b/crontabs/porkcron.reboot
@@ -1,0 +1,1 @@
+@reboot root /usr/local/bin/porkcron

--- a/crontabs/porkcron.weekly
+++ b/crontabs/porkcron.weekly
@@ -1,0 +1,1 @@
+0 0 * * 1 root /usr/local/bin/porkcron

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.10-alpine
 COPY ../porkcron.py /usr/local/bin/porkcron
 RUN chmod +x /usr/local/bin/porkcron
 
-COPY crontab /etc/crontabs/root
+RUN mkdir -p /etc/porkcron/crontabs
+COPY ../crontabs/* /etc/porkcron/crontabs/
+RUN cat /etc/porkcron/crontabs/* | sed 's/ root / /g' > /etc/crontabs/root
 
 CMD [ "crond", "-f" ]

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,3 +1,0 @@
-# run on container startup
-@reboot /usr/local/bin/porkcron
-@weekly /usr/local/bin/porkcron

--- a/standalone/install.sh
+++ b/standalone/install.sh
@@ -9,9 +9,8 @@ mkdir -p /etc/porkcron
 cp ../porkcron.py /etc/porkcron/porkcron.py
 chmod +x /etc/porkcron/porkcron.py
 
-# Add a cron entry for it to run on reboot and weekly
-echo '0 0 * * 1 root /usr/local/bin/porkcron' > /etc/cron.d/porkcron.weekly
-echo '@reboot root /usr/local/bin/porkcron' >> /etc/cron.d/porkcron.reboot
+# Add a cron entries for it to run on reboot and weekly
+cp ../crontabs/* /etc/cron.d/
 
 # Run once if the .env file exists
 if [ -e ../.env ]

--- a/standalone/install.sh
+++ b/standalone/install.sh
@@ -10,7 +10,16 @@ cp ../porkcron.py /etc/porkcron/porkcron.py
 chmod +x /etc/porkcron/porkcron.py
 
 # Add a cron entries for it to run on reboot and weekly
-cp ../crontabs/* /etc/cron.d/
+if [ -d /etc/cron.d ]
+then
+  cp ../crontabs/* /etc/cron.d/
+else
+  echo "Could not detect /etc/cron.d to set up the cronjobs. Please set these up manually."
+  echo "The two relevant lines to add are:"
+  cat ../crontabs/*
+  echo ""
+  echo "You might have to take out the username to run as depending on your flavor of cron."
+fi
 
 # Run once if the .env file exists
 if [ -e ../.env ]

--- a/standalone/install.sh
+++ b/standalone/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+# Install porkcron as a standalone executable script
+cd "$(dirname "$0")"
+cp ../porkcron.sh /usr/local/bin/porkcron
+chmod +x /usr/local/bin/porkcron
+
+mkdir -p /etc/porkcron
+cp ../porkcron.py /etc/porkcron/porkcron.py
+chmod +x /etc/porkcron/porkcron.py
+
+# Add a cron entry for it to run on reboot and weekly
+echo '@weekly /usr/local/bin/porkcron' > /etc/cron.d/porkcron
+echo '@reboot /usr/local/bin/porkcron' >> /etc/cron.d/porkcron
+
+# Run once
+/usr/local/bin/porkcron

--- a/standalone/install.sh
+++ b/standalone/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 # Install porkcron as a standalone executable script
 cd "$(dirname "$0")"

--- a/standalone/install.sh
+++ b/standalone/install.sh
@@ -10,8 +10,14 @@ cp ../porkcron.py /etc/porkcron/porkcron.py
 chmod +x /etc/porkcron/porkcron.py
 
 # Add a cron entry for it to run on reboot and weekly
-echo '@weekly /usr/local/bin/porkcron' > /etc/cron.d/porkcron
-echo '@reboot /usr/local/bin/porkcron' >> /etc/cron.d/porkcron
+echo '0 0 * * 0 /usr/local/bin/porkcron' > /etc/cron.d/porkcron.weekly
+echo '@reboot /usr/local/bin/porkcron' >> /etc/cron.d/porkcron.reboot
 
-# Run once
-/usr/local/bin/porkcron
+# Run once if the .env file exists
+if [ -e ../.env ]
+then
+  cp ../.env /etc/porkcron/.env
+  /usr/local/bin/porkcron
+else
+  echo "Please fill out the required values for $(dirname "$PWD")/.env.example and copy or move it to /etc/porkcron/.env before running porkcron for the first time."
+fi

--- a/standalone/install.sh
+++ b/standalone/install.sh
@@ -10,7 +10,7 @@ cp ../porkcron.py /etc/porkcron/porkcron.py
 chmod +x /etc/porkcron/porkcron.py
 
 # Add a cron entry for it to run on reboot and weekly
-echo '0 0 * * 0 root /usr/local/bin/porkcron' > /etc/cron.d/porkcron.weekly
+echo '0 0 * * 1 root /usr/local/bin/porkcron' > /etc/cron.d/porkcron.weekly
 echo '@reboot root /usr/local/bin/porkcron' >> /etc/cron.d/porkcron.reboot
 
 # Run once if the .env file exists

--- a/standalone/install.sh
+++ b/standalone/install.sh
@@ -10,8 +10,8 @@ cp ../porkcron.py /etc/porkcron/porkcron.py
 chmod +x /etc/porkcron/porkcron.py
 
 # Add a cron entry for it to run on reboot and weekly
-echo '0 0 * * 0 /usr/local/bin/porkcron' > /etc/cron.d/porkcron.weekly
-echo '@reboot /usr/local/bin/porkcron' >> /etc/cron.d/porkcron.reboot
+echo '0 0 * * 0 root /usr/local/bin/porkcron' > /etc/cron.d/porkcron.weekly
+echo '@reboot root /usr/local/bin/porkcron' >> /etc/cron.d/porkcron.reboot
 
 # Run once if the .env file exists
 if [ -e ../.env ]

--- a/standalone/porkcron.sh
+++ b/standalone/porkcron.sh
@@ -7,6 +7,12 @@ cd /etc/porkcron
 if [ -e .env ]
 then
   while IFS== read -r key value; do
+    case $key in
+      ''|\#*) continue ;;
+    esac
+    case $value in
+      \ \#*|\#*) continue ;;
+    esac
     printf -v "$key" %s "$value"
     export "$key"
   done <.env

--- a/standalone/porkcron.sh
+++ b/standalone/porkcron.sh
@@ -6,16 +6,7 @@ cd /etc/porkcron
 # Read the .env file if it exists
 if [ -e .env ]
 then
-  while IFS== read -r key value; do
-    case $key in
-      ''|\ \#*|\#*) continue ;;
-    esac
-    case $value in
-      \ \#*|\#*) continue ;;
-    esac
-    printf -v "$key" %s "$value"
-    export "$key"
-  done <.env
+  export $(grep -v '^\s*#' .env | xargs | sed 's/, /,/g')
 else
   echo "Could not find $PWD/.env to fetch the latest SSL certs!" 1>&2
   echo "Trying anyway, it should work if the correct environment variables are set elsewhere." 1>&2

--- a/standalone/porkcron.sh
+++ b/standalone/porkcron.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 # Move to /etc/porkcron
 cd /etc/porkcron

--- a/standalone/porkcron.sh
+++ b/standalone/porkcron.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+# Move to /etc/porkcron
+cd /etc/porkcron
+
+# Read the .env file if it exists
+if [ -e .env ]
+then
+  while IFS== read -r key value; do
+    printf -v "$key" %s "$value"
+    export "$key"
+  done <.env
+else
+  echo "Could not find $PWD/.env to fetch the latest SSL certs!" 1>&2
+  echo "Trying anyway, it should work if the correct environment variables are set elsewhere." 1>&2
+fi
+
+./porkcron.py

--- a/standalone/porkcron.sh
+++ b/standalone/porkcron.sh
@@ -8,7 +8,7 @@ if [ -e .env ]
 then
   while IFS== read -r key value; do
     case $key in
-      ''|\#*) continue ;;
+      ''|\ \#*|\#*) continue ;;
     esac
     case $value in
       \ \#*|\#*) continue ;;


### PR DESCRIPTION
Fixes #8 
Shortly after opening it I realized I might as well write it myself. All it really needs is a crontab entry and a wrapper that can turn the .env file into a bunch of environment variables. This is almost that, just needs a small tweak to ignore blank lines and lines starting with a # as these currently make `printf` error